### PR TITLE
Update docker image to ruby:3.2.2-alpine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,10 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '3.2.2'
 
+## Core rails stuff
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'rails', '~> 6.1.3'
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3', '~> 1.4'
 # Use Puma as the app server
 gem 'puma', '~> 5.0'
 # Use SCSS for stylesheets
@@ -17,20 +17,20 @@ gem 'webpacker', '~> 5.0'
 gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.7'
-# Use Redis adapter to run Action Cable in production
-# gem 'redis', '~> 4.0'
-# Use Active Model has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
-
-# Use Active Storage variant
-# gem 'image_processing', '~> 1.2'
-
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+
+## Gems that require special installation for the ruby:3.2.2-alpine image
+
+# ActiveRecord requires version ~1.4, which means we have to complie sqlite in the ruby 3.2.2 docker image
+gem 'sqlite3', '~> 1.4', force_ruby_platform: true
+gem 'nokogiri', '~> 1.16', force_ruby_platform: true
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'rspec-rails'
 end
 
@@ -39,8 +39,9 @@ group :development do
   gem 'web-console', '>= 4.1.0'
   # Display performance information such as SQL time and flame graphs for each request in your browser.
   # Can be configured to work on production as well see: https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md
-  gem 'rack-mini-profiler', '~> 2.0'
   gem 'listen', '~> 3.3'
+  gem 'rack-mini-profiler', '~> 2.0'
+  gem 'rubocop', '~> 1.64'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
 end
@@ -50,8 +51,3 @@ group :test do
   gem 'capybara', '>= 3.26'
   gem 'selenium-webdriver'
 end
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-
-gem "rubocop", "~> 1.64"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
-version: "3.9"
 services:
   supporters:
-    build: .
+    build:
+      context: .
+      target: server
     volumes: 
       - .:/usr/src/app
       - /dev/null:/usr/src/app/Gemfile.lock
-    command: sh -c "bin/rails db:migrate RAILS_ENV=development && bundle exec rake db:seed && rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     ports:
       - "3000:3000"


### PR DESCRIPTION
Main things necessary:
- sqlite was not included in the new image by default, so it has to be apk'd
- sqlite3 and nokogiri gems have to compile for the ruby platform